### PR TITLE
Added support for new-style modules

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 extern crate rust_bundler_cp;
 
-use std::process;
 use clap::App;
 use std::collections::HashMap;
+use std::process;
 
 use rust_bundler_cp::BundlerConfig;
 
@@ -24,20 +24,15 @@ fn main() {
         .args_from_usage("--remove_unused_mod 'If a pub mod statement in lib.rs is not used in selected bin, it would be removed EXPERIMENTAL!!'")
         .get_matches();
 
-
     let path: String = match matches.value_of("input") {
         None => {
             eprintln!("Error! Input path have to be specified");
             process::exit(1);
         }
-        Some(v) => String::from(v)
+        Some(v) => String::from(v),
     };
 
-    let binary_selected = match matches.value_of("binary") {
-        None => None,
-        Some(v) => Some(String::from(v))
-    };
-
+    let binary_selected = matches.value_of("binary").map(String::from);
 
     let mut config: HashMap<BundlerConfig, String> = HashMap::new();
 

--- a/tests/bin.rs
+++ b/tests/bin.rs
@@ -1,39 +1,38 @@
 extern crate assert_cli;
 
 use assert_cli::Assert;
-use std::fs::{DirEntry, read_dir};
 
 #[test]
 fn usage() {
-    cli_bundle(&[],
-               false,
-               &["Error! Input path have to be specified"])
+    cli_bundle(&[], false, &["Error! Input path have to be specified"])
 }
 
 #[test]
 fn bundle_self() {
-    cli_bundle(&["--input", "."],
-               true,
-               &["pub fn bundle<", "let code = bundle("])
-
+    cli_bundle(
+        &["--input", "."],
+        true,
+        &["pub fn bundle<", "let code = bundle("],
+    )
 }
 
 #[test]
 fn multiple_binaries() {
     for c in 'a'..='g' {
         let binary = c.to_string();
-        cli_bundle(&["--input", "testdata/input/multiple_binaries", "-b", &binary],
-               true,
-               &["pub fn bundle<", "let code = bundle("])
+        cli_bundle(
+            &["--input", "testdata/input/multiple_binaries", "-b", &binary],
+            true,
+            &["pub fn bundle<", "let code = bundle("],
+        )
     }
-
 }
 
-fn cli_bundle(args: &[&str], success: bool, expect_output: &[&str]) -> () {
+fn cli_bundle(args: &[&str], success: bool, expect_output: &[&str]) {
     let mut assert = Assert::main_binary().with_args(args);
     if success {
         assert = assert.succeeds();
-    }  else {
+    } else {
         assert = assert.fails();
     }
     for s in expect_output {

--- a/tests/golden.rs
+++ b/tests/golden.rs
@@ -1,16 +1,16 @@
-extern crate rust_bundler_cp;
 extern crate goldenfile;
+extern crate rust_bundler_cp;
 
-use std::io::Write;
+use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use goldenfile::Mint;
-use std::fs::DirEntry;
 
-const INPUT_DIR: &'static str = "tests/testdata/input";
-const OUTPUT_DIR: &'static str = "tests/testdata/output";
-const MULTIPLE_BINARIES_TEST_NAME: &'static str = "multiple_binaries";
+const INPUT_DIR: &str = "tests/testdata/input";
+const OUTPUT_DIR: &str = "tests/testdata/output";
+const MULTIPLE_BINARIES_TEST_NAME: &str = "multiple_binaries";
 
 #[test]
 fn loop_test_cases() {
@@ -27,14 +27,13 @@ fn loop_test_cases() {
     }
 }
 
-fn golden(mint:&mut Mint, input_path: PathBuf) {
+fn golden(mint: &mut Mint, input_path: PathBuf) {
     let input_name = input_path.file_name().expect("no file name");
     let output_name = Path::new(input_name).with_extension("rs");
-    let mut output_file = mint.new_goldenfile(output_name).expect(
-        "new_goldenfile failed",
-    );
-    let output = rust_bundler_cp::bundle(&input_path);
+    let mut output_file = mint
+        .new_goldenfile(output_name)
+        .expect("new_goldenfile failed");
+    let output = rust_bundler_cp::bundle_specific_binary(&input_path, None, HashMap::new());
     write!(output_file, "{}", output).expect("write! failed");
     output_file.flush().expect("flush failed");
-
 }

--- a/tests/parse_test_io.rs
+++ b/tests/parse_test_io.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use std::io::Read;
+use std::path::Path;
 #[test]
 fn parse_test_io() {
     let code_path_str = "tests/testdata/test_io.rs";
@@ -7,23 +7,24 @@ fn parse_test_io() {
     // let base_path = Path::new(&lib.src_path).parent()
     //     .expect("lib.src_path has no parent");
 
-    let lib_rs_code =
-        read_file(code_path).expect("failed to read lib.rs");
+    let lib_rs_code = read_file(code_path).expect("failed to read lib.rs");
     // debug!("Loaded lib.rs: {}", lib_rs_code.len());
     let lib = syn::parse_file(&lib_rs_code).expect("failed to parse lib.rs");
     print!("parsed lib: {}", lib.items.len());
 }
 
-
 fn read_file(path: &Path) -> Option<String> {
     let mut buf = String::new();
-    std::fs::File::open(path).ok()?.read_to_string(&mut buf).ok()?;
+    std::fs::File::open(path)
+        .ok()?
+        .read_to_string(&mut buf)
+        .ok()?;
     Some(buf)
 }
 
 #[test]
 fn parse_pub_mod() {
     let lib_rs_code = "pub mod algo;";
-    let lib = syn::parse_file(&lib_rs_code).expect("failed to parse lib.rs");
+    let lib = syn::parse_file(lib_rs_code).expect("failed to parse lib.rs");
     print!("parsed lib: {}", lib.items.len());
 }

--- a/tests/testdata/input/no_mod_file/Cargo.toml
+++ b/tests/testdata/input/no_mod_file/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "complicated"
+version = "0.1.0"
+authors = ["Slava Shklyaev <slava@slava.sh>"]
+edition = "2018"
+
+[lib]
+name = "my_lib"
+
+[dependencies]

--- a/tests/testdata/input/no_mod_file/src/a.rs
+++ b/tests/testdata/input/no_mod_file/src/a.rs
@@ -1,0 +1,3 @@
+pub fn a() {
+    println!("a::a()");
+}

--- a/tests/testdata/input/no_mod_file/src/b.rs
+++ b/tests/testdata/input/no_mod_file/src/b.rs
@@ -1,0 +1,5 @@
+use crate::a;
+
+pub fn b() {
+    a::a();
+}

--- a/tests/testdata/input/no_mod_file/src/c.rs
+++ b/tests/testdata/input/no_mod_file/src/c.rs
@@ -1,0 +1,1 @@
+pub mod d;

--- a/tests/testdata/input/no_mod_file/src/c/d.rs
+++ b/tests/testdata/input/no_mod_file/src/c/d.rs
@@ -1,0 +1,3 @@
+pub fn d() {
+    println!("c::d::d()");
+}

--- a/tests/testdata/input/no_mod_file/src/lib.rs
+++ b/tests/testdata/input/no_mod_file/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod a;
+pub mod b;
+pub mod c;

--- a/tests/testdata/input/no_mod_file/src/main.rs
+++ b/tests/testdata/input/no_mod_file/src/main.rs
@@ -1,0 +1,9 @@
+extern crate my_lib;
+
+use my_lib::{a, b, c};
+
+fn main() {
+    a::a();
+    self::b::b();
+    self::c::d::d();
+}

--- a/tests/testdata/output/no_mod_file.rs
+++ b/tests/testdata/output/no_mod_file.rs
@@ -1,0 +1,23 @@
+pub mod a {
+    pub fn a() {
+        println!("a::a()");
+    }
+}
+pub mod b {
+    use crate::a;
+    pub fn b() {
+        a::a();
+    }
+}
+pub mod c {
+    pub mod d {
+        pub fn d() {
+            println!("c::d::d()");
+        }
+    }
+}
+fn main() {
+    a::a();
+    self::b::b();
+    self::c::d::d();
+}


### PR DESCRIPTION
- Added support for modules that have the module definition outside the module folder (instead of having a `mod.rs` file in the folder).
- Added enforcing of Unix line ending to avoid tests to fail under Windows
- Added test for the new code.

Sadly my `rustfmt` has constantly reformatted the code. I am not sure why.