### PR TITLE
Handle crate names containing hyphens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub fn bundle_specific_binary<P: AsRef<Path>>(
     let base_path = Path::new(&lib.src_path)
         .parent()
         .expect("lib.src_path has no parent");
-    let crate_name = &lib.name;
+    let crate_name = &lib.name.replace("-", "_");
 
     info!("Expanding binary {:?}", bin.src_path);
     let syntax_tree =

--- a/tests/testdata/input/simple-hyphen/Cargo.toml
+++ b/tests/testdata/input/simple-hyphen/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "simple-hyphen"
+version = "0.1.0"
+authors = ["Slava Shklyaev <slava@slava.sh>", "Kåre von Geijer <kare.kvg@gmail.com>"]
+edition = "2018"
+
+[dependencies]

--- a/tests/testdata/input/simple-hyphen/src/internal.rs
+++ b/tests/testdata/input/simple-hyphen/src/internal.rs
@@ -1,0 +1,3 @@
+pub fn hello_world() {
+    println!("Hello, world!");
+}

--- a/tests/testdata/input/simple-hyphen/src/lib.rs
+++ b/tests/testdata/input/simple-hyphen/src/lib.rs
@@ -1,0 +1,3 @@
+mod internal;
+
+pub use internal::hello_world;

--- a/tests/testdata/input/simple-hyphen/src/main.rs
+++ b/tests/testdata/input/simple-hyphen/src/main.rs
@@ -1,0 +1,6 @@
+// The hyphen in "simple-hyphen" gets converted to an underscore in the code
+extern crate simple_hyphen;
+
+fn main() {
+    simple_hyphen::hello_world();
+}

--- a/tests/testdata/output/simple-hyphen.rs
+++ b/tests/testdata/output/simple-hyphen.rs
@@ -1,0 +1,9 @@
+mod internal {
+    pub fn hello_world() {
+        println!("Hello, world!");
+    }
+}
+pub use internal::hello_world;
+fn main() {
+    hello_world();
+}


### PR DESCRIPTION
Crates in rust are allowed to contain '-' in their names. But these dashes are all converted to '_' in the code to not confuse the name with subtraction. This commit adds this switch into the code, making it no longer confused for names containing '-'.

As an example, the bundler does not in its current state work for my small competetive Rust template ([https://github.com/KvGeijer/comp-rust-template](https://github.com/KvGeijer/comp-rust-template)), but it does work after this fix.